### PR TITLE
fix darkened videos

### DIFF
--- a/theme.xml
+++ b/theme.xml
@@ -290,8 +290,6 @@ license:       creative commons CC-BY-NC-SA
          <effect>none</effect>
          <showSnapshotDelay>true</showSnapshotDelay>
          <showSnapshotNoVideo>true</showSnapshotNoVideo>
-         <color ifSubset="gamelist-view-style:metadata-on-immersive">FFFFFFDD</color>
-         <color ifSubset="gamelist-view-style:metadata-off-immersive">FFFFFF99</color>
          <zIndex>3</zIndex>
          <loops ifSubset="gamelist-loop-video:off">0</loops>
          <loops ifSubset="gamelist-loop-video:on">-1</loops>


### PR DESCRIPTION
This is subjective so go ahead and just close this if it is not helpful. I noticed the videos were appearing darker than the images and found this was the culprit. I'm not really a theme dev and I'm not totally sure if this fix is appropriate based on how this theme was designed, but it's working for me. Maybe it will help others. 